### PR TITLE
chore: upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Closes linancn/TianGong-LCA-Data#28

## Summary
- Upgrade every active workflow checkout reference to actions/checkout@v7.

## Validation
- Parsed all changed workflow YAML files; docpact lint and git diff --check passed.

## Risks / Rollback
- Low-risk CI dependency major-version update; rollback is a one-line version reversion.

## Workspace Integration
- Submodule repositories require a later exact-SHA workspace pointer update after merge.